### PR TITLE
Hide Datastream.Systems from JSON responses

### DIFF
--- a/internal/model/domains/datastream.go
+++ b/internal/model/domains/datastream.go
@@ -54,7 +54,7 @@ type Datastream struct {
 	FeatureOfInterestID *string `gorm:"type:varchar(255);index" json:"-"`
 	SamplingFeatureID   *string `gorm:"type:varchar(255);index" json:"-"`
 
-	Systems []System `gorm:"many2many:system_datastreams;"`
+	Systems []System `gorm:"many2many:system_datastreams;" json:"-"`
 }
 
 // TableName specifies the table name.


### PR DESCRIPTION
## Summary

Adds `json:"-"` to the `Datastream.Systems` `many2many` GORM field in `internal/model/domains/datastream.go` so it stops leaking into every datastream JSON response as `"Systems": null`. Brings the field in line with the convention every other relationship/foreign-key field in `internal/model/domains/` already follows.

## Why this matters

Issue #15 documents the response-shape pollution: `Datastream` has a `Systems []System` field for the `system_datastreams` join table, but unlike the other internal relationship fields the field has no `json:"-"` tag, so Go's `encoding/json` falls back to the default behavior and emits `"Systems": null` on every datastream item.

The same file already establishes the convention right above the offending line. `SystemID`, `ProcedureID`, `DeploymentID`, `FeatureOfInterestID`, and `SamplingFeatureID` are all tagged `json:"-"` (lines 51-55). Other domain files in the same directory (`system.go`, `system_event.go`, `feature.go`, `control_stream.go`) follow the same pattern. The `Systems` field is the sole deviation.

The "Reproduction" curl from issue #15 §2.8 confirms the symptom on `4b99421`: `.items[0]` has a `Systems` key with `null` value. After the change, the field is dropped from the JSON entirely, matching how every other relationship field renders.

## Changes

`internal/model/domains/datastream.go` line 57: appends `json:"-"` to the existing GORM struct tag. The GORM `many2many:system_datastreams;` directive is preserved (so the join behavior is unchanged), and the Go-side field name and visibility are unchanged (so any in-process code that reads `datastream.Systems` continues to work).

```diff
- Systems []System `gorm:"many2many:system_datastreams;"`
+ Systems []System `gorm:"many2many:system_datastreams;" json:"-"`
```

## Testing

`go build ./internal/model/domains/...` is clean against the change. `go build ./...` against the broader tree fails on a pre-existing `unknown field CommonSSN in struct literal of type domains.Datastream` in `internal/model/generators/generators_datastream.go:177` -- that error reproduces on `main` without this diff, so it is not introduced here.

After the change, the JSON shape from `GET /datastreams` no longer carries the `"Systems": null` key (encoding/json drops fields tagged `-` regardless of value). The reproduction curl from the issue should return `has_Systems_capital: false`.

Closes #15
